### PR TITLE
Allow only admin user to create maps and dashboards

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -492,7 +492,12 @@
               "name": "PHOTOMAP"
             }
           },
-          "MapSearch", "CreateNewMap", "FeaturedMaps", "ContentTabs",
+          "MapSearch", {
+            "name": "CreateNewMap",
+            "cfg": {
+              "allowedRoles": "ADMIN"
+            }
+          }, "FeaturedMaps", "ContentTabs",
           {
             "name": "Maps",
             "cfg": {


### PR DESCRIPTION
This PR changes the configuration to show new map and new dashboard button only to admin users.