### PR TITLE
Fix #18. Add cookie fragments, setup title for surveye theme.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,14 +21,15 @@ for ARGUMENT in "$@"; do
     esac
 
 done
-
+COMPILE_OPTS="";
 MAVEN_PROPERTIES="-Dmapstore2.version=$VERSION"
 if [ -n "$THEME" ]; then
-    MAVEN_PROPERTIES="$MAVEN_PROPERTIES -Dtheme=$THEME"
+    MAVEN_PROPERTIES="$MAVEN_PROPERTIES -Dtheme=$THEME" # adds theme profile for copy correct resources
+    COMPILE_OPTS=" -- --env.theme=$THEME"; # add theme env variable for webpack template customizations
 fi
 
 npm install
-npm run compile
+npm run compile $COMPILE_OPTS
 npm run lint
 
 mvn -U clean install $MAVEN_PROPERTIES;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/parser": {
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+            "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+            "dev": true
+        },
         "@babel/runtime": {
             "version": "7.5.5",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
@@ -6183,7 +6189,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -6204,12 +6211,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -6224,17 +6233,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -6351,7 +6363,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -6363,6 +6376,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -6377,6 +6391,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -6384,12 +6399,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -6408,6 +6425,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -6488,7 +6506,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -6500,6 +6519,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -6585,7 +6605,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -6621,6 +6642,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -6640,6 +6662,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -6683,12 +6706,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -8676,6 +8701,12 @@
                 "tmp": "0.0.31"
             },
             "dependencies": {
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+                    "dev": true
+                },
                 "fs-extra": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
@@ -8686,6 +8717,45 @@
                         "jsonfile": "^2.1.0"
                     }
                 },
+                "js2xmlparser": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
+                    "integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
+                    "dev": true,
+                    "requires": {
+                        "xmlcreate": "^2.0.0"
+                    }
+                },
+                "jsdoc": {
+                    "version": "3.6.3",
+                    "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz",
+                    "integrity": "sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/parser": "^7.4.4",
+                        "bluebird": "^3.5.4",
+                        "catharsis": "^0.8.11",
+                        "escape-string-regexp": "^2.0.0",
+                        "js2xmlparser": "^4.0.0",
+                        "klaw": "^3.0.0",
+                        "markdown-it": "^8.4.2",
+                        "markdown-it-anchor": "^5.0.2",
+                        "marked": "^0.7.0",
+                        "mkdirp": "^0.5.1",
+                        "requizzle": "^0.2.3",
+                        "strip-json-comments": "^3.0.1",
+                        "taffydb": "2.6.2",
+                        "underscore": "~1.9.1"
+                    },
+                    "dependencies": {
+                        "bluebird": {
+                            "version": "3.5.5",
+                            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+                            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+                            "dev": true
+                        }
+                    }
+                },
                 "jsonfile": {
                     "version": "2.4.0",
                     "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -8694,6 +8764,39 @@
                     "requires": {
                         "graceful-fs": "^4.1.6"
                     }
+                },
+                "klaw": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+                    "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.9"
+                    }
+                },
+                "marked": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+                    "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+                    "dev": true
+                },
+                "strip-json-comments": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+                    "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+                    "dev": true
+                },
+                "underscore": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+                    "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+                    "dev": true
+                },
+                "xmlcreate": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
+                    "integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
+                    "dev": true
                 }
             }
         },
@@ -9610,6 +9713,15 @@
                 "immediate": "~3.0.5"
             }
         },
+        "linkify-it": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "dev": true,
+            "requires": {
+                "uc.micro": "^1.0.1"
+            }
+        },
         "load-json-file": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -9958,6 +10070,33 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "markdown-it": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+            "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "entities": "~1.1.1",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+                    "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+                    "dev": true
+                }
+            }
+        },
+        "markdown-it-anchor": {
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz",
+            "integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==",
+            "dev": true
+        },
         "marked": {
             "version": "0.3.19",
             "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
@@ -10002,6 +10141,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.2.0.tgz",
             "integrity": "sha512-esDqNvsJB2q5V28+u7NdtdMg6Rmg4khQmAVSjUiX7BY/7haIv0K2yWM43hYp0or+3nvG7+UaTF1JHz31hgU1TA=="
+        },
+        "mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+            "dev": true
         },
         "media-typer": {
             "version": "0.3.0",
@@ -11768,6 +11913,13 @@
             "requires": {
                 "mgrs": "1.0.0",
                 "wkt-parser": "^1.2.0"
+            },
+            "dependencies": {
+                "wkt-parser": {
+                    "version": "1.2.3",
+                    "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.3.tgz",
+                    "integrity": "sha512-s7zrOedGuHbbzMaQOuf8HacuCYp3LmmrHjkkN//7UEAzsYz7xJ6J+j/84ZWZkQcrRqi3xXyuc4odPHj7PEB0bw=="
+                }
             }
         },
         "promise": {
@@ -14273,6 +14425,11 @@
                         "mgrs": "1.0.0",
                         "wkt-parser": "^1.2.0"
                     }
+                },
+                "wkt-parser": {
+                    "version": "1.2.3",
+                    "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.3.tgz",
+                    "integrity": "sha512-s7zrOedGuHbbzMaQOuf8HacuCYp3LmmrHjkkN//7UEAzsYz7xJ6J+j/84ZWZkQcrRqi3xXyuc4odPHj7PEB0bw=="
                 }
             }
         },
@@ -15641,6 +15798,12 @@
             "version": "0.7.20",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
             "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
+        },
+        "uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+            "dev": true
         },
         "uglify-js": {
             "version": "2.8.29",

--- a/prod-webpack.config.js
+++ b/prod-webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const path = require("path");
 
 const extractThemesPlugin = require('./MapStore2/themes.js').extractThemesPlugin;
@@ -10,41 +11,48 @@ const paths = {
     code: [path.join(__dirname, "js"), path.join(__dirname, "MapStore2", "web", "client")]
 };
 
-module.exports = require('./MapStore2/buildConfig')(
-    {
-        'MapStore-C148': path.join(__dirname, "js", "app"),
-        'MapStore-C148-embedded': path.join(__dirname, "MapStore2", "web", "client", "product", "embedded"),
-        'MapStore-C148-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api")
-    },
-    {
-        "themes/default": path.join(__dirname, "assets", "themes", "default", "theme.less"),
-        "themes/surveye": path.join(__dirname, "assets", "themes", "surveye", "theme.less")
-    },
-    paths,
-    extractThemesPlugin,
-    true,
-    "/mapstore/dist/",
-    '.MapStore-C148',
-    [
-        new HtmlWebpackPlugin({
-            template: path.join(__dirname, 'indexTemplate.html'),
-            chunks: ['MapStore-C148'],
-            inject: true,
-            hash: true
-        }),
-        new HtmlWebpackPlugin({
-            template: path.join(__dirname, 'embeddedTemplate.html'),
-            chunks: ['MapStore-C148-embedded'],
-            inject: true,
-            hash: true,
-            filename: 'embedded.html'
-        }),
-        new HtmlWebpackPlugin({
-            template: path.join(__dirname, 'apiTemplate.html'),
-            chunks: ['MapStore-C148-api'],
-            inject: 'head',
-            hash: true,
-            filename: 'api.html'
-        })
-    ]
-);
+module.exports = env => {
+    const theme = env && env.theme;
+    console.log("compiling for theme " + (theme || "default"));
+    return require('./MapStore2/buildConfig')(
+        {
+            'MapStore-C148': path.join(__dirname, "js", "app"),
+            'MapStore-C148-embedded': path.join(__dirname, "MapStore2", "web", "client", "product", "embedded"),
+            'MapStore-C148-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api")
+        },
+        {
+            "themes/default": path.join(__dirname, "assets", "themes", "default", "theme.less"),
+            "themes/surveye": path.join(__dirname, "assets", "themes", "surveye", "theme.less")
+        },
+        paths,
+        extractThemesPlugin,
+        true,
+        "/mapstore/dist/",
+        '.MapStore-C148',
+        [
+            new HtmlWebpackPlugin({
+                // TODO: couldn't use title in HtmlWebpackPlugin options. try to find a way to use instead of this workaround and do the same for favicon(actually it uses a copy in pom.xml)
+                template: path.join(__dirname, (theme ? (theme + "-") : "") + 'indexTemplate.html'),
+                chunks: ['MapStore-C148'],
+                inject: true,
+                hash: true
+            }),
+            new HtmlWebpackPlugin({
+                // TODO: couldn't use title in HtmlWebpackPlugin options. try to find a way to use instead of this workaround and do the same for favicon(actually it uses a copy in pom.xml)
+                template: path.join(__dirname, (theme ? (theme + "-") : "") + 'embeddedTemplate.html'),
+                chunks: ['MapStore-C148-embedded'],
+                inject: true,
+                hash: true,
+                filename: 'embedded.html'
+            }),
+            new HtmlWebpackPlugin({
+                // TODO: couldn't use title in HtmlWebpackPlugin options. try to find a way to use instead of this workaround and do the same for favicon(actually it uses a copy in pom.xml)
+                template: path.join(__dirname, (theme ? (theme + "-") : "" ) + 'apiTemplate.html'),
+                chunks: ['MapStore-C148-api'],
+                inject: 'head',
+                hash: true,
+                filename: 'api.html'
+            })
+        ]
+    );
+};

--- a/surveye-apiTemplate.html
+++ b/surveye-apiTemplate.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>SURVEYE</title>
+        <link href="https://fonts.googleapis.com/css?family=Montserrat|Open+Sans" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css" />
+        <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+        <script src="https://maps.google.com/maps/api/js?v=3"></script>
+        <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
+        <style>
+        #container {
+            position: absolute;
+            top: 100px;
+            left: 100px;
+            right: 100px;
+            bottom: 100px;
+        }
+        #mapstore2-embedded, #map, .fill {
+            width: 100%;
+            height: 100%;
+        }
+        </style>
+    </head>
+    <body onload="init()">
+        <div id="container" class="ms2"></div>
+        <script type="text/javascript">
+        function init() {
+            MapStore2.create('container', {
+                originalUrl: "./#viewer/leaflet/0"
+            });
+        }
+        </script>
+    </body>
+</html>

--- a/surveye-embeddedTemplate.html
+++ b/surveye-embeddedTemplate.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>SURVEYE</title>
+        <style>
+            body {
+                margin: 0;
+            }
+            ._ms2_init_center {
+                position: fixed;
+                top: 0;
+                left: 0;
+                bottom: 0;
+                right: 0;
+                overflow: show;
+                margin: auto;
+                display: flex;
+                align-items: center;
+            }
+            ._ms2_init_spinner {
+                height: 176px;
+                width: 176px;
+            }
+            ._ms2_init_spinner > div,
+            ._ms2_init_spinner > div:after {
+                border-radius: 50%;
+                width: 176px;
+                height: 176px;
+            }
+            ._ms2_init_spinner > div {
+                box-sizing: border-box;
+                text-indent: -9999em;
+                border: 16px solid rgba(119,119,119, 0.2);
+                border-left: 16px solid #777777;
+                -webkit-transform: translateZ(0);
+                -ms-transform: translateZ(0);
+                transform: translateZ(0);
+                -webkit-animation: _ms2_init_anim 1.1s infinite linear;
+                animation: _ms2_init_anim 1.1s infinite linear;
+            }
+            @-webkit-keyframes _ms2_init_anim {
+                0% {
+                -webkit-transform: rotate(0deg);
+                transform: rotate(0deg);
+                }
+                100% {
+                -webkit-transform: rotate(360deg);
+                transform: rotate(360deg);
+                }
+            }
+            @keyframes _ms2_init_anim {
+                0% {
+                -webkit-transform: rotate(0deg);
+                transform: rotate(0deg);
+                }
+                100% {
+                -webkit-transform: rotate(360deg);
+                transform: rotate(360deg);
+                }
+            }
+            ._ms2_init_text {
+                -webkit-animation: _ms2_init_text_anim 2s linear 0s infinite normal;
+                animation: _ms2_init_text_anim 2s linear 0s infinite normal;
+                color: #6F6F6f;
+                font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+                font-size: 20px;
+                font-weight: bold;
+                height: 0.75em;
+                width:  6em;
+                text-align: center;
+                margin: auto;
+                z-index: 1000;
+            }
+            @keyframes _ms2_init_text_anim {
+                0%  {opacity: 0}
+                20% {opacity: 0}
+                50% {opacity: 1}
+                70% {opacity: .75}
+                100%{opacity: 0}
+            }
+        </style>
+        <link href="https://fonts.googleapis.com/css?family=Montserrat|Open+Sans" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css" />
+        <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+        <script src="https://maps.google.com/maps/api/js?v=3"></script>
+        <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
+    </head>
+    <body>
+        <div id="container">
+            <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
+            <div class="_ms2_init_text _ms2_init_center">Loading MapStore</div>
+        </div>
+    </body>
+</html>

--- a/surveye-indexTemplate.html
+++ b/surveye-indexTemplate.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+  <head>
+      <meta charset="UTF-8">
+      <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
+      <title>SURVEYE</title>
+      <style>
+      body {
+        margin: 0;
+      }
+      ._ms2_init_center {
+        position: fixed;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        overflow: show;
+        margin: auto;
+        display: flex;
+        align-items: center;
+      }
+      ._ms2_init_spinner {
+        height: 176px;
+        width: 176px;
+      }
+      ._ms2_init_spinner > div,
+      ._ms2_init_spinner > div:after {
+        border-radius: 50%;
+        width: 176px;
+        height: 176px;
+      }
+      ._ms2_init_spinner > div {
+        box-sizing: border-box;
+        text-indent: -9999em;
+        border: 16px solid rgba(119,119,119, 0.2);
+        border-left: 16px solid #777777;
+        -webkit-transform: translateZ(0);
+        -ms-transform: translateZ(0);
+        transform: translateZ(0);
+        -webkit-animation: _ms2_init_anim 1.1s infinite linear;
+        animation: _ms2_init_anim 1.1s infinite linear;
+      }
+      @-webkit-keyframes _ms2_init_anim {
+        0% {
+          -webkit-transform: rotate(0deg);
+          transform: rotate(0deg);
+        }
+        100% {
+          -webkit-transform: rotate(360deg);
+          transform: rotate(360deg);
+        }
+      }
+      @keyframes _ms2_init_anim {
+        0% {
+          -webkit-transform: rotate(0deg);
+          transform: rotate(0deg);
+        }
+        100% {
+          -webkit-transform: rotate(360deg);
+          transform: rotate(360deg);
+        }
+      }
+      ._ms2_init_text {
+        -webkit-animation: _ms2_init_text_anim 2s linear 0s infinite normal;
+        animation: _ms2_init_text_anim 2s linear 0s infinite normal;
+        color: #6F6F6f;
+        font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+        font-size: 20px;
+        font-weight: bold;
+        height: 0.75em;
+        width:  6em;
+        text-align: center;
+        margin: auto;
+        z-index: 1000;
+      }
+      @keyframes _ms2_init_text_anim {
+        0%  {opacity: 0}
+        20% {opacity: 0}
+        50% {opacity: 1}
+        70% {opacity: .75}
+        100%{opacity: 0}
+      }
+      </style>
+      <link href="https://fonts.googleapis.com/css?family=Montserrat|Open+Sans" rel="stylesheet">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" />
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css" />
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.4/ol.css" />
+      <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+      <script src="https://maps.google.com/maps/api/js?v=3"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.4/ol.js"></script>
+      <script src="https://cesiumjs.org/releases/1.17/Build/Cesium/Cesium.js"></script>
+      <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
+      <script src="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.js"></script>
+      <link rel="stylesheet" href="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.css" />
+
+  </head>
+  <body>
+      <div id="container">
+          <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
+          <div class="_ms2_init_text _ms2_init_center">Loading MapStore</div>
+      </div>
+  </body>
+</html>

--- a/translations/fragments/cookie/cookieDetails-de-DE.html
+++ b/translations/fragments/cookie/cookieDetails-de-DE.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div>
+            <div className="cookie-seeMore">
+                <h2 style="font-weight: bold">Cookies Policy</h2>
+                <hr />
+                <p style="line-height: 100%">
+In Übereinstimmung mit dem Gesetzesdekret Nr. 196/2003, das das Gesetz Nr. 675/1996 zum Schutz personenbezogener Daten ersetzt, informieren wir Sie, dass Sie mit der weiteren Nutzung dieser Website der Verarbeitung Ihrer persönlichen Daten (sensible Daten werden in keiner Weise behandelt), die GeoSolutions SAS durch elektronische und/oder automatische Tools erworben hat, zustimmen. In jedem Fall ist es möglich, die Rechte zu nutzen, die dem Benutzer in Übereinstimmung mit Gesetzesdekret Nr. 196/2003 (Zugang zu Daten, Aktualisierung, Integration, Löschung) gewährt werden. Durch Klicken auf den Button "Akzeptieren" erklären Sie, dass Sie diesen Text gelesen haben und der Verarbeitung personenbezogener Daten zustimmen. Sie können die Redakteure von GeoSolutions SAS jederzeit bitten, sich von dem Dienst abzumelden, indem Sie den Anweisungen am Ende jeder Nachricht folgen.
+                </p>
+                <h4 style="font-weight: bold">Was sind Cookies?</h4>
+                <p style="line-height: 100%">Ein Cookie ist eine Textdatei, die eine Website im Browser des Benutzers speichert. Cookies erlauben normalerweise, die vom Benutzer geäußerten Präferenzen zu speichern, um später nicht wieder eingefügt zu werden. Der Browser speichert die Informationen und sendet sie an den Standortserver zurück, wenn der Benutzer diese Website erneut besucht.</p>
+                <p style="line-height: 100%">Unsere Cookies helfen uns:</p>
+                <ul>
+                    <li>Die Website wie erwartet funktionieren zu lassen</li>
+                    <li>Die Einstellungen während und zwischen den Besuchen der Seite zu merken</li>
+                    <li>Die Geschwindigkeit der Website-Sicherheit zu verbessern</li>
+                    <li>Es erlaubt Seiten mit sozialen Netzwerken wie Facebook zu teilen</li>
+                </ul>
+                <p style="line-height: 100%">Cookies werden nicht verwendet um:</p>
+                <ul>
+                    <li>Alle persönlich identifizierbaren Informationen (ohne Ihre Zustimmung) zu sammeln</li>
+                    <li>Alle sensible Daten (ohne explizite Zustimmung) zu sammeln</li>
+                    <li>Daten an Werbenetzwerke zu übergeben</li>
+                    <li>Personenbezogener Daten an Dritte weiterzugeben</li>
+					<li>Kostenpflichtige Verkaufsaufträge zu tätigen</li>
+                </ul>
+                <p style="line-height: 100%">Hier unten können Sie mehr über alle Cookies die wir verwende, erfahren.</p>
+                <p style="line-height: 100%">Wenn die Einstellungen der Software, die Sie zum Durchsuchen der Website (des Browsers) verwenden, auf das Akzeptieren von Cookies eingestellt sind, akzeptieren wir diese und die fortgesetzte Nutzung unserer Website als Zustimmung zur Verwendung von Cookies. Wenn Sie Cookies von unserer Website entfernen oder nicht verwenden möchten, können Sie dies tun, indem Sie den unten stehenden Anweisungen folgen. Dies könnte jedoch dazu führen, dass unsere Website nicht wie erwartet funktioniert.</p>
+
+                <h4 style="font-weight: bold">Unsere Cookies</h4>
+                <p style="line-height: 100%">Wir verwenden Cookies, um bestimmte Funktionen der Website zu gewährleisten, einschließlich:</p>
+                <ul>
+                    <li>Anmeldevorgänge und anschließende Authentifizierung</li>
+                    <li>Authentifizierung für WMS-, WFS-, WPS-Dienste über HTTP-Anfragen</li>
+                </ul>
+                <p style="line-height: 100%">Es gibt keine Möglichkeit zu verhindern, dass diese Cookies gesetzt werden, als unsere Seite nicht zu benutzen.</p>
+                <h4 style="font-weight: bold">Cookies von Dritten</h4>
+                <p style="line-height: 100%">Unsere Website enthält wie viele andere Funktionen und Dienste, die von Dritten angeboten werden. Ein gängiges Beispiel ist die Einbettung eines YouTube-Videos. Unsere Website enthält die folgenden Cookies:</p>
+                <ul>
+                    <li><a href="http://www.google.it/intl/it/policies/privacy/" target="_blank">Google</a></li>
+                    <li><a href="https://www.cloudflare.com/cookie-policy/" target="_blank">Cloudflare</a></li>
+                </ul>
+                <h4 style="font-weight: bold">Social Website Cookies</h4>
+                <p style="line-height: 100%">Sie können einfach Ihre Meinung äußern oder Inhalte auf Facebook und Twitter teilen (wir haben die Freigabetasten auf unserer Seite eingefügt). Cookies wurden aktiviert für:</p>
+                <ul>
+                    <li>Twitter</li>
+                    <li>Facebook</li>
+                    <li>Linkedin</li>
+                    <li>Google +</li>
+                </ul>
+                <p style="line-height: 100%">Die Auswirkungen auf die Privatsphäre variieren von sozialen Netzwerken zu sozialen Netzwerken und hängen von den Datenschutzeinstellungen ab, die Sie in diesen Netzwerken gewählt haben.</p>
+                <h4 style="font-weight: bold">Deaktivieren von Cookies</h4>
+                <p style="line-height: 100%">
+                    Normalerweise können Sie Cookies deaktivieren, indem Sie Ihre Browsereinstellungen ändern, um deren Verwendung zu verhindern(siehe <a href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank">hier</a>). Dies wird jedoch wahrscheinlich die Funktionalität unserer sowie vieler Websites auf der ganzen Welt einschränken (Cookies sind ein Standardbestandteil der meisten modernen Websites).
+                </p>
+                <p style="line-height: 100%">
+                    Es kann sein, dass sich Ihre Cookie-bezogenen Bedenken auf sogenannte "Spyware" beziehen. Anstatt die Cookies in Ihrem Browser zu deaktivieren, können Sie erkennen, dass die Anti-Spyware-Software das gleiche Ziel erreicht, indem Cookies, die als invasiv angesehen werden, automatisch entfernt werden. Bitte lesen <a href="http://www.attacat.co.uk/resources/cookies/how-to-control-your-online-privacy" target="_blank">wieSie Cookies mit Anti-Spyware-Software verwalten</a></a>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/translations/fragments/cookie/cookieDetails-en-PT.html
+++ b/translations/fragments/cookie/cookieDetails-en-PT.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div className="cookie-seeMore">
+            <h2 style="font-weight: bold">Cookies Policy</h2>
+            <hr />
+            <p style="line-height: 100%">
+                In accordance with Law Decree n° 196/2003, which replaced the Law n° 675/1996 concerning the protection of personal data, we inform you that by filling out this form and then sending this email message, you consent to the processing of your personal data (sensitive data will not be processed in any way) acquired by GeoSolutions SAS via electronic and/or automated tools. In any case, you can exercise your rights granted to you pursuant to Legislative Decree n° 196/2003 (data access, updates, integration, cancellation). Clicking the “Accept” button, you acknowledge that you have read this text and that you consent to the processing of your personal data. At any time you can ask the staff of GeoSolutions SAS web site to unsubscribe you from the service by following the instructions at the end of each message.
+            </p>
+            <h4 style="font-weight: bold">Cookies and how they Benefit You</h4>
+            <p style="line-height: 100%">Our website uses cookies, as almost all websites do, to help provide you with the best experience we can. Cookies are small text files that are placed on your computer or mobile phone when you browse websites</p>
+            <p style="line-height: 100%">Our cookies help us:</p>
+            <ul>
+                <li>Make our website work as you’d expect</li>
+                <li>Remember your settings during and between visits</li>
+                <li>Improve the speed/security of the site</li>
+                <li>Allow you to share pages with social networks like Facebook</li>
+            </ul>
+            <p style="line-height: 100%">We do not use cookies to:</p>
+            <ul>
+                <li>Collect any personally identifiable information (without your express permission)</li>
+                <li>Collect any sensitive information (without your express permission)</li>
+                <li>Pass data to advertising networks</li>
+                <li>Pass personally identifiable data to third parties</li>
+                <li>Pay sales commissions</li>
+            </ul>
+            <p style="line-height: 100%">You can learn more about all the cookies we use below.</p>
+            <p style="line-height: 100%">If the settings on your software that you are using to view this website (your browser) are adjusted to accept cookies we take this, and your continued use of our website, to mean that you are fine with this. Should you wish to remove or not use cookies from our site you can learn how to do this below, however doing so will likely mean that our site will not work as you would expect.</p>
+
+            <h4 style="font-weight: bold">Our own cookies</h4>
+            <p style="line-height: 100%">We use cookies to make our website work including:</p>
+            <ul>
+                <li>Remembering your search settings</li>
+                <li>Authentication to WMS, WFS, WPS via HTTP requests</li>
+            </ul>
+            <p style="line-height: 100%">There is no way to prevent these cookies being set other than to not use our site.</p>
+            <h4 style="font-weight: bold">Third Party Cookies</h4>
+            <p style="line-height: 100%">Our site, like most websites, includes functionality provided by third parties. A common example is an embedded YouTube video. Our site includes the following which use cookies:</p>
+            <ul>
+                <li><a href="http://www.google.it/intl/en/policies/privacy/" target="_blank">Google</a></li>
+                <li><a href="https://www.cloudflare.com/cookie-policy/" target="_blank">Cloudflare</a></li>
+            </ul>
+            <h4 style="font-weight: bold">Social Website Cookies</h4>
+            <p style="line-height: 100%">So you can easily like or share our content on the likes of Facebook and Twitter we have included sharing buttons on our site. Cookies are set by:</p>
+            <ul>
+                <li>Twitter</li>
+                <li>Facebook</li>
+                <li>Linkedin</li>
+                <li>Google +</li>
+            </ul>
+            <p style="line-height: 100%">The privacy implications on this will vary from social network to social network and will be dependent on the privacy settings you have chosen on these networks.</p>
+            <h4 style="font-weight: bold">Turning Cookies Off</h4>
+            <p style="line-height: 100%">
+                You can usually switch cookies off by adjusting your browser settings to stop it from accepting cookies (learn how <a      href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank"> here</a>.). Doing so however will likely limit the functionality of our’s  and a large proportion of the world’s websites as cookies are a standard part of most modern websites.
+            </p>
+            <p style="line-height: 100%">
+                It may be that you concerns around cookies relate to so called “spyware”. Rather than switching off cookies in your browser you may find that anti-spyware software achieves the same objective by automatically deleting cookies considered to be invasive. Learn more about <a href="http://www.attacat.co.uk/resources/cookies/how-to-control-your-online-privacy" target="_blank"> managing cookies with antispyware software</a>.
+            </p>
+        </div>
+    </body>
+</html>

--- a/translations/fragments/cookie/cookieDetails-en-US.html
+++ b/translations/fragments/cookie/cookieDetails-en-US.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div className="cookie-seeMore">
+            <h2 style="font-weight: bold">Cookies Policy</h2>
+            <hr />
+            <p style="line-height: 100%">
+                In accordance with Law Decree n° 196/2003, which replaced the Law n° 675/1996 concerning the protection of personal data, we inform you that by filling out this form and then sending this email message, you consent to the processing of your personal data (sensitive data will not be processed in any way) acquired by GeoSolutions SAS via electronic and/or automated tools. In any case, you can exercise your rights granted to you pursuant to Legislative Decree n° 196/2003 (data access, updates, integration, cancellation). Clicking the “Accept” button, you acknowledge that you have read this text and that you consent to the processing of your personal data. At any time you can ask the staff of GeoSolutions SAS web site to unsubscribe you from the service by following the instructions at the end of each message.
+            </p>
+            <h4 style="font-weight: bold">Cookies and how they Benefit You</h4>
+            <p style="line-height: 100%">Our website uses cookies, as almost all websites do, to help provide you with the best experience we can. Cookies are small text files that are placed on your computer or mobile phone when you browse websites</p>
+            <p style="line-height: 100%">Our cookies help us:</p>
+            <ul>
+                <li>Make our website work as you’d expect</li>
+                <li>Remember your settings during and between visits</li>
+                <li>Improve the speed/security of the site</li>
+                <li>Allow you to share pages with social networks like Facebook</li>
+            </ul>
+            <p style="line-height: 100%">We do not use cookies to:</p>
+            <ul>
+                <li>Collect any personally identifiable information (without your express permission)</li>
+                <li>Collect any sensitive information (without your express permission)</li>
+                <li>Pass data to advertising networks</li>
+                <li>Pass personally identifiable data to third parties</li>
+                <li>Pay sales commissions</li>
+            </ul>
+            <p style="line-height: 100%">You can learn more about all the cookies we use below.</p>
+            <p style="line-height: 100%">If the settings on your software that you are using to view this website (your browser) are adjusted to accept cookies we take this, and your continued use of our website, to mean that you are fine with this. Should you wish to remove or not use cookies from our site you can learn how to do this below, however doing so will likely mean that our site will not work as you would expect.</p>
+
+            <h4 style="font-weight: bold">Our own cookies</h4>
+            <p style="line-height: 100%">We use cookies to make our website work including:</p>
+            <ul>
+                <li>Remembering your search settings</li>
+                <li>Authentication to WMS, WFS, WPS via HTTP requests</li>
+            </ul>
+            <p style="line-height: 100%">There is no way to prevent these cookies being set other than to not use our site.</p>
+            <h4 style="font-weight: bold">Third Party Cookies</h4>
+            <p style="line-height: 100%">Our site, like most websites, includes functionality provided by third parties. A common example is an embedded YouTube video. Our site includes the following which use cookies:</p>
+            <ul>
+                <li><a href="http://www.google.it/intl/en/policies/privacy/" target="_blank">Google</a></li>
+                <li><a href="https://www.cloudflare.com/cookie-policy/" target="_blank">Cloudflare</a></li>
+            </ul>
+            <h4 style="font-weight: bold">Social Website Cookies</h4>
+            <p style="line-height: 100%">So you can easily like or share our content on the likes of Facebook and Twitter we have included sharing buttons on our site. Cookies are set by:</p>
+            <ul>
+                <li>Twitter</li>
+                <li>Facebook</li>
+                <li>Linkedin</li>
+                <li>Google +</li>
+            </ul>
+            <p style="line-height: 100%">The privacy implications on this will vary from social network to social network and will be dependent on the privacy settings you have chosen on these networks.</p>
+            <h4 style="font-weight: bold">Turning Cookies Off</h4>
+            <p style="line-height: 100%">
+                You can usually switch cookies off by adjusting your browser settings to stop it from accepting cookies (learn how <a      href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank"> here</a>.). Doing so however will likely limit the functionality of our’s  and a large proportion of the world’s websites as cookies are a standard part of most modern websites.
+            </p>
+            <p style="line-height: 100%">
+                It may be that you concerns around cookies relate to so called “spyware”. Rather than switching off cookies in your browser you may find that anti-spyware software achieves the same objective by automatically deleting cookies considered to be invasive. Learn more about <a href="http://www.attacat.co.uk/resources/cookies/how-to-control-your-online-privacy" target="_blank"> managing cookies with antispyware software</a>.
+            </p>
+        </div>
+    </body>
+</html>

--- a/translations/fragments/cookie/cookieDetails-es-ES.html
+++ b/translations/fragments/cookie/cookieDetails-es-ES.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div className="cookie-seeMore">
+            <h2 style="font-weight: bold">Cookies Policy</h2>
+            <hr />
+            <p style="line-height: 100%">
+                In accordance with Law Decree n° 196/2003, which replaced the Law n° 675/1996 concerning the protection of personal data, we inform you that by filling out this form and then sending this email message, you consent to the processing of your personal data (sensitive data will not be processed in any way) acquired by GeoSolutions SAS via electronic and/or automated tools. In any case, you can exercise your rights granted to you pursuant to Legislative Decree n° 196/2003 (data access, updates, integration, cancellation). Clicking the “Accept” button, you acknowledge that you have read this text and that you consent to the processing of your personal data. At any time you can ask the staff of GeoSolutions SAS web site to unsubscribe you from the service by following the instructions at the end of each message.
+            </p>
+            <h4 style="font-weight: bold">Cookies and how they Benefit You</h4>
+            <p style="line-height: 100%">Our website uses cookies, as almost all websites do, to help provide you with the best experience we can. Cookies are small text files that are placed on your computer or mobile phone when you browse websites</p>
+            <p style="line-height: 100%">Our cookies help us:</p>
+            <ul>
+                <li>Make our website work as you’d expect</li>
+                <li>Remember your settings during and between visits</li>
+                <li>Improve the speed/security of the site</li>
+                <li>Allow you to share pages with social networks like Facebook</li>
+            </ul>
+            <p style="line-height: 100%">We do not use cookies to:</p>
+            <ul>
+                <li>Collect any personally identifiable information (without your express permission)</li>
+                <li>Collect any sensitive information (without your express permission)</li>
+                <li>Pass data to advertising networks</li>
+                <li>Pass personally identifiable data to third parties</li>
+                <li>Pay sales commissions</li>
+            </ul>
+            <p style="line-height: 100%">You can learn more about all the cookies we use below.</p>
+            <p style="line-height: 100%">If the settings on your software that you are using to view this website (your browser) are adjusted to accept cookies we take this, and your continued use of our website, to mean that you are fine with this. Should you wish to remove or not use cookies from our site you can learn how to do this below, however doing so will likely mean that our site will not work as you would expect.</p>
+
+            <h4 style="font-weight: bold">Our own cookies</h4>
+            <p style="line-height: 100%">We use cookies to make our website work including:</p>
+            <ul>
+                <li>Remembering your search settings</li>
+                <li>Authentication to WMS, WFS, WPS via HTTP requests</li>
+            </ul>
+            <p style="line-height: 100%">There is no way to prevent these cookies being set other than to not use our site.</p>
+            <h4 style="font-weight: bold">Third Party Cookies</h4>
+            <p style="line-height: 100%">Our site, like most websites, includes functionality provided by third parties. A common example is an embedded YouTube video. Our site includes the following which use cookies:</p>
+            <ul>
+                <li><a href="http://www.google.it/intl/de/policies/privacy/" target="_blank">Google</a></li>
+                <li><a href="https://www.cloudflare.com/cookie-policy/" target="_blank">Cloudflare</a></li>
+            </ul>
+            <h4 style="font-weight: bold">Social Website Cookies</h4>
+            <p style="line-height: 100%">So you can easily like or share our content on the likes of Facebook and Twitter we have included sharing buttons on our site. Cookies are set by:</p>
+            <ul>
+                <li>Twitter</li>
+                <li>Facebook</li>
+                <li>Linkedin</li>
+                <li>Google +</li>
+            </ul>
+            <p style="line-height: 100%">The privacy implications on this will vary from social network to social network and will be dependent on the privacy settings you have chosen on these networks.</p>
+            <h4 style="font-weight: bold">Turning Cookies Off</h4>
+            <p style="line-height: 100%">
+                You can usually switch cookies off by adjusting your browser settings to stop it from accepting cookies (learn how <a      href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank"> here</a>.). Doing so however will likely limit the functionality of our’s  and a large proportion of the world’s websites as cookies are a standard part of most modern websites.
+            </p>
+            <p style="line-height: 100%">
+                It may be that you concerns around cookies relate to so called “spyware”. Rather than switching off cookies in your browser you may find that anti-spyware software achieves the same objective by automatically deleting cookies considered to be invasive. Learn more about <a href="http://www.attacat.co.uk/resources/cookies/how-to-control-your-online-privacy" target="_blank"> managing cookies with antispyware software</a>.
+            </p>
+        </div>
+    </body>
+</html>

--- a/translations/fragments/cookie/cookieDetails-fr-FR.html
+++ b/translations/fragments/cookie/cookieDetails-fr-FR.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div className="cookie-seeMore">
+            <h2 style="font-weight: bold">Cookies Policy</h2>
+            <hr />
+            <p style="line-height: 100%">
+                In accordance with Law Decree n° 196/2003, which replaced the Law n° 675/1996 concerning the protection of personal data, we inform you that by filling out this form and then sending this email message, you consent to the processing of your personal data (sensitive data will not be processed in any way) acquired by GeoSolutions SAS via electronic and/or automated tools. In any case, you can exercise your rights granted to you pursuant to Legislative Decree n° 196/2003 (data access, updates, integration, cancellation). Clicking the “Accept” button, you acknowledge that you have read this text and that you consent to the processing of your personal data. At any time you can ask the staff of GeoSolutions SAS web site to unsubscribe you from the service by following the instructions at the end of each message.
+            </p>
+            <h4 style="font-weight: bold">Cookies and how they Benefit You</h4>
+            <p style="line-height: 100%">Our website uses cookies, as almost all websites do, to help provide you with the best experience we can. Cookies are small text files that are placed on your computer or mobile phone when you browse websites</p>
+            <p style="line-height: 100%">Our cookies help us:</p>
+            <ul>
+                <li>Make our website work as you’d expect</li>
+                <li>Remember your settings during and between visits</li>
+                <li>Improve the speed/security of the site</li>
+                <li>Allow you to share pages with social networks like Facebook</li>
+            </ul>
+            <p style="line-height: 100%">We do not use cookies to:</p>
+            <ul>
+                <li>Collect any personally identifiable information (without your express permission)</li>
+                <li>Collect any sensitive information (without your express permission)</li>
+                <li>Pass data to advertising networks</li>
+                <li>Pass personally identifiable data to third parties</li>
+                <li>Pay sales commissions</li>
+            </ul>
+            <p style="line-height: 100%">You can learn more about all the cookies we use below.</p>
+            <p style="line-height: 100%">If the settings on your software that you are using to view this website (your browser) are adjusted to accept cookies we take this, and your continued use of our website, to mean that you are fine with this. Should you wish to remove or not use cookies from our site you can learn how to do this below, however doing so will likely mean that our site will not work as you would expect.</p>
+
+            <h4 style="font-weight: bold">Our own cookies</h4>
+            <p style="line-height: 100%">We use cookies to make our website work including:</p>
+            <ul>
+                <li>Remembering your search settings</li>
+                <li>Authentication to WMS, WFS, WPS via HTTP requests</li>
+            </ul>
+            <p style="line-height: 100%">There is no way to prevent these cookies being set other than to not use our site.</p>
+            <h4 style="font-weight: bold">Third Party Cookies</h4>
+            <p style="line-height: 100%">Our site, like most websites, includes functionality provided by third parties. A common example is an embedded YouTube video. Our site includes the following which use cookies:</p>
+            <ul>
+                <li><a href="http://www.google.it/intl/fr/policies/privacy/" target="_blank">Google</a></li>
+                <li><a href="https://www.cloudflare.com/cookie-policy/" target="_blank">Cloudflare</a></li>
+            </ul>
+            <h4 style="font-weight: bold">Social Website Cookies</h4>
+            <p style="line-height: 100%">So you can easily like or share our content on the likes of Facebook and Twitter we have included sharing buttons on our site. Cookies are set by:</p>
+            <ul>
+                <li>Twitter</li>
+                <li>Facebook</li>
+                <li>Linkedin</li>
+                <li>Google +</li>
+            </ul>
+            <p style="line-height: 100%">The privacy implications on this will vary from social network to social network and will be dependent on the privacy settings you have chosen on these networks.</p>
+            <h4 style="font-weight: bold">Turning Cookies Off</h4>
+            <p style="line-height: 100%">
+                You can usually switch cookies off by adjusting your browser settings to stop it from accepting cookies (learn how <a      href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank"> here</a>.). Doing so however will likely limit the functionality of our’s  and a large proportion of the world’s websites as cookies are a standard part of most modern websites.
+            </p>
+            <p style="line-height: 100%">
+                It may be that you concerns around cookies relate to so called “spyware”. Rather than switching off cookies in your browser you may find that anti-spyware software achieves the same objective by automatically deleting cookies considered to be invasive. Learn more about <a href="http://www.attacat.co.uk/resources/cookies/how-to-control-your-online-privacy" target="_blank"> managing cookies with antispyware software</a>.
+            </p>
+        </div>
+    </body>
+</html>

--- a/translations/fragments/cookie/cookieDetails-hr-HR.html
+++ b/translations/fragments/cookie/cookieDetails-hr-HR.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div className="cookie-seeMore">
+            <h2 style="font-weight: bold">Politika kolačića</h2>
+            <hr />
+            <p style="line-height: 100%">
+                Sukladno Uredbi br. 196/2003, koja je zamijenila Zakon br. 675/1996 o zaštiti osobnih podataka, obavještavamo Vas da ispunjavanjem ovog obrasca i slanjem ove poruke putem e-pošte pristajete na obradu vaših osobnih podataka (osjetljivi podaci neće biti obrađivani na bilo koji način) koje je GeoSolutions SAS stekao putem elektroničkih i/ili automatiziranih alata. U svakom slučaju možete ostvariti svoja prava koja su Vam dodijeljena sukladno Zakonodavnoj uredbi br. 196/2003 (pristup podacima, ažuriranja, integracija, otkazivanje). Klikom na gumb "Prihvati" potvrđujete da ste pročitali ovaj tekst i da pristajete na obradu vaših osobnih podataka. U bilo kojem trenutku možete zatražiti od osoblja GeoSolutions SAS web stranica da vas odjave sa usluge slijedeći upute na kraju svake poruke.
+            </p>
+            <h4 style="font-weight: bold">Kolačići i njihova korist za Vas</h4>
+            <p style="line-height: 100%">Naša web stranica koristi kolačiće, kao i gotovo sve web stranice, kako bi Vam pružila najbolje moguće iskustvo. Kolačići su male tekstualne datoteke koje se pohranjuju na vašem računalu ili mobilnom telefonu prilikom pregledavanja web stranica</p>
+            <p style="line-height: 100%">Naši kolačići pomažu kako bi:</p>
+            <ul>
+                <li>Naše web stranice radile na način na koji Vi očekujete</li>
+                <li>Zapamtili Vaše postavke za vrijeme i između različitih posjeta</li>
+                <li>Poboljšali brzinu/sigurnost web stranice</li>
+                <li>Omogućili dijeljenje stanica sa socijanlnim mrežama kao npr. Facebook</li>
+            </ul>
+            <p style="line-height: 100%">Ne koristimo kolačiće za:</p>
+            <ul>
+                <li>Prikupljanje bilo kojeg osobnog podatka (bez vašeg izričitog dopuštenja)</li>
+                <li>Prikupljanje bilo kojeg osjetljivog podatka (bez vašeg izričitog dopuštenja)</li>
+                <li>Proslijeđivanje podataka nekoj od oglašivačkih mreža</li>
+                <li>Prenošenje osobnih podataka trećim stranama</li>
+                <li>Plaćanje provizije</li>
+            </ul>
+            <p style="line-height: 100%">Možete saznati više o svim kolačićima koje koristimo ispod.</p>
+            <p style="line-height: 100%">Ako su postavke vašeg softvera koji koristite za pregled ove web stranice (vaš preglednik) prilagođene za prihvaćanje kolačića, uzimamo to i vašu daljnju upotrebu naše web stranice kao da se podrazumijeva da ste suglasni sa ovakvim načinom rada. Ako želite ukloniti ili ne koristiti kolačiće s naše web stranice, možete saznati kako to učiniti u nastavku, ali to će vjerojatno značiti da naša web stranica neće raditi na način kako biste očekivali.</p>
+
+            <h4 style="font-weight: bold">Naši kolačići</h4>
+            <p style="line-height: 100%">Koristimo kolačiće kako bi naša web stranica radila uključujući i:</p>
+            <ul>
+                <li>Pamćenje Vaših postavki pretraživanja</li>
+                <li>Korisničke podatke za prijavu na WMS, WFS, WPS putem HTTP zahtjeva</li>
+            </ul>
+            <p style="line-height: 100%">Nema načina da se spriječi postavljanje ovih kolačića, osim da ne koristite našu web stranicu.</p>
+            <h4 style="font-weight: bold">Kolačići trećih strana</h4>
+            <p style="line-height: 100%">Naša stranica, poput većine web stranica, uključuje i funkcionalnosti koju pružaju treće strane. Uobičajeni primjer je ugrađeni YouTube videozapis. Naša web stranica uključuje slijedeće koje koriste kolačiće:</p>
+            <ul>
+                <li><a href="http://www.google.it/intl/en/policies/privacy/" target="_blank">Google</a></li>
+                <li><a href="https://www.cloudflare.com/cookie-policy/" target="_blank">Cloudflare</a></li>
+            </ul>
+            <h4 style="font-weight: bold">Kolačići socijalnih mreža</h4>
+            <p style="line-height: 100%">Na taj način jednostavno možete "lajkati" ili dijeliti naš sadržaj na Facebook i Twitter koje smo uključili u dijeljenje gumba na našoj web stranici. Kolačiće postavljaju:</p>
+            <ul>
+                <li>Twitter</li>
+                <li>Facebook</li>
+                <li>Linkedin</li>
+                <li>Google +</li>
+            </ul>
+            <p style="line-height: 100%">Postavke privatnosti u ovim slučajevima će se razlikovati od društvene mreže do društvene mreže i ovisiti će o postavkama privatnosti koje ste odabrali na tim mrežama.</p>
+            <h4 style="font-weight: bold">Isključivanje kolačića</h4>
+            <p style="line-height: 100%">
+                Kolačiće obično možete isključiti prilagodbom postavki preglednika kako biste spriječili prihvaćanje kolačića (saznajte kako <a href = "http://www.attacat.co.uk/resources/cookies/how-to-ban" target = " _blank "> ovdje</a>). Međutim, to će vjerojatno ograničiti funkcionalnost našeg i velikog broja web stranica na svijetu jer su kolačići standardni dio suvremenijih web stranica.
+            </p>
+            <p style="line-height: 100%">
+                Može biti da se Vaša zabrinutost oko kolačića odnosi na tzv. "Spyware". Umjesto isključivanja kolačića u vašem pregledniku, možete otkriti da anti-spyware softver postiže isti cilj automatski brišući kolačiće koji se smatraju invazivnim. Saznajte više o <a href="http://www.attacat.co.uk/resources/cookies/how-to-control-your-online-privacy" target="_blank"> upravljanju kolačićima pomoću antispyware softvera</a>.
+            </p>
+        </div>
+    </body>
+</html>

--- a/translations/fragments/cookie/cookieDetails-it-IT.html
+++ b/translations/fragments/cookie/cookieDetails-it-IT.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div>
+            <div className="cookie-seeMore">
+                <h2 style="font-weight: bold">Cookies Policy</h2>
+                <hr />
+                <p style="line-height: 100%">
+                    Ai sensi del Decreto Legislativo n ° 196/2003, che ha sostituito la legge n ° 675/1996 in materia di protezione dei dati personali, Vi informiamo che proseguendo la navigazione su questo sito voi acconsentite al trattamento dei vostri dati personali (i dati sensibili non saranno trattati in alcun modo) acquisiti da GeoSolutions SAS tramite strumenti elettronici e/o automatici. In ogni caso, è possibile esercitare i diritti concessi all'utente ai sensi del Decreto Legislativo n ° 196/2003 (accesso ai dati, aggiornamento, integrazione, cancellazione). Facendo clic sul pulsante “Accetto”, si dichiara di aver letto questo testo e di acconsentire al trattamento dei dati personali. In qualsiasi momento è possibile chiedere alla redazione di GeoSolutions SAS del sito di cancellarti dal servizio seguendo le istruzioni alla fine di ogni messaggio.
+                </p>
+                <h4 style="font-weight: bold">Cosa sono i Cookies?</h4>
+                <p style="line-height: 100%">Un cookie è un file di testo che un sito web salva sul browser del computer dell’utente. Solitamente i cookie consentono di memorizzare le preferenze espresse dall’utente per non dover essere reinserite successivamente. Il browser salva l’informazione e la ritrasmette al server del sito nel momento in cui l’utente visita nuovamente quel sito web.</p>
+                <p style="line-height: 100%">I nostri cookie ci aiutano a:</p>
+                <ul>
+                    <li>Permettere al sito web di lavorare come atteso</li>
+                    <li>Ricordare le impostazioni durante e tra le visite al sito</li>
+                    <li>Migliorare la velocità  sicurezza del sito</li>
+                    <li>Permette di condividere le pagine con i social network come Facebook</li>
+                </ul>
+                <p style="line-height: 100%">Non viene fatto uso di cookies per:</p>
+                <ul>
+                    <li>Raccogliere tutte le informazioni di identificazione personale (senza il vostro consenso)</li>
+                    <li>Raccogliere tutte le informazioni sensibili (senza il tuo esplicito consenso)</li>
+                    <li>Passare i dati alle reti pubblicitarie</li>
+                    <li>Passare dati personali a terze parti</li>
+                    <li>Commissioni di vendita a pagamento</li>
+                </ul>
+                <p style="line-height: 100%">Potete saperne di più su tutti i cookies che utilizziamo qui sotto.</p>
+                <p style="line-height: 100%">Se le impostazioni del software che si sta utilizzando per la navigazione del sito (il browser) sono regolati per accettare i cookies prendiamo questo, e l'uso continuato del nostro sito web, a significare che si acconsente all'utilizzo di cookies. Se si desidera rimuovere o non usare i cookies dal nostro sito lo si può fare seguendo le indicazioni riportate di seguito, così facendo tuttavia il nostro sito potrebbe non  funzionare come ci si aspetterebbe.</p>
+
+                <h4 style="font-weight: bold">I nostri Cookies</h4>
+                <p style="line-height: 100%">Utilizziamo i cookie per garantire determinate funzionalità del sito web tra cui:</p>
+                <ul>
+                    <li>Operazioni di Login e successive autenticazioni</li>
+                    <li>Autenticazione a servizi WMS, WFS, WPS attraverso richieste HTTP</li>
+                </ul>
+                <p style="line-height: 100%">Non è possibile prevenire che questi cookies There is no way to prevent these cookies being set other than to not use our site.</p>
+                <h4 style="font-weight: bold">Cookies di Terze Parti</h4>
+                <p style="line-height: 100%">Il nostro sito, come molti, include funzionalità e servizi offerti da terze parti. Un comune esempio è l'embed di un video di YouTube. Il nostro sito include i seguenti cookie:</p>
+                <ul>
+                    <li><a href="http://www.google.it/intl/it/policies/privacy/" target="_blank">Google</a></li>
+                    <li><a href="https://www.cloudflare.com/cookie-policy/" target="_blank">Cloudflare</a></li>
+                </ul>
+                <h4 style="font-weight: bold">Social Website Cookies</h4>
+                <p style="line-height: 100%">Tu puoi facilmente esprimere il tuo gradimento o condividere alcuni contenuti su Facebook e Twitter (abbiamo incluso i pulsanti di condivisione sul nostro sito). I cookies sono stati abilitati per:</p>
+                <ul>
+                    <li>Twitter</li>
+                    <li>Facebook</li>
+                    <li>Linkedin</li>
+                    <li>Google +</li>
+                </ul>
+                <p style="line-height: 100%">Le implicazioni di privacy su questo variano da social network a social network e dipenderanno dalle impostazioni di privacy che avete scelto su queste reti.</p>
+                <h4 style="font-weight: bold">Disabilitare i Cookies</h4>
+                <p style="line-height: 100%">
+                    Di solito è possibile disattivare i cookies modificando le impostazioni del browser per impedire l'uso degli stessi (vedi <a href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank"> qui</a>. In questo modo però probabilmente si limiteranno le funzionalità del nostro come di molti dei siti web di tutto il mondo (i cookie sono una componente standard della maggior parte dei siti web moderni).
+                </p>
+                <p style="line-height: 100%">
+                    Potrebbe essere che le tue preoccupazioni relativi ai cookie riguardino i cosiddetti "spyware". Piuttosto che disattivare i cookie nel tuo browser puoi sapere che il software anti-spyware raggiunge lo stesso obiettivo eliminando automaticamente i cookie considerati invasivi. Leggi come <a href="http://www.attacat.co.uk/resources/cookies/how-to-control-your-online-privacy" target="_blank"> gestire i cookie con software antispyware</a>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/translations/fragments/cookie/cookieDetails-nl-NL.html
+++ b/translations/fragments/cookie/cookieDetails-nl-NL.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div className="cookie-seeMore">
+            <h2 style="font-weight: bold">Cookies Policy</h2>
+            <hr />
+            <p style="line-height: 100%">
+                In accordance with Law Decree n° 196/2003, which replaced the Law n° 675/1996 concerning the protection of personal data, we inform you that by filling out this form and then sending this email message, you consent to the processing of your personal data (sensitive data will not be processed in any way) acquired by GeoSolutions SAS via electronic and/or automated tools. In any case, you can exercise your rights granted to you pursuant to Legislative Decree n° 196/2003 (data access, updates, integration, cancellation). Clicking the “Accept” button, you acknowledge that you have read this text and that you consent to the processing of your personal data. At any time you can ask the staff of GeoSolutions SAS web site to unsubscribe you from the service by following the instructions at the end of each message.
+            </p>
+            <h4 style="font-weight: bold">Cookies and how they Benefit You</h4>
+            <p style="line-height: 100%">Our website uses cookies, as almost all websites do, to help provide you with the best experience we can. Cookies are small text files that are placed on your computer or mobile phone when you browse websites</p>
+            <p style="line-height: 100%">Our cookies help us:</p>
+            <ul>
+                <li>Make our website work as you’d expect</li>
+                <li>Remember your settings during and between visits</li>
+                <li>Improve the speed/security of the site</li>
+                <li>Allow you to share pages with social networks like Facebook</li>
+            </ul>
+            <p style="line-height: 100%">We do not use cookies to:</p>
+            <ul>
+                <li>Collect any personally identifiable information (without your express permission)</li>
+                <li>Collect any sensitive information (without your express permission)</li>
+                <li>Pass data to advertising networks</li>
+                <li>Pass personally identifiable data to third parties</li>
+                <li>Pay sales commissions</li>
+            </ul>
+            <p style="line-height: 100%">You can learn more about all the cookies we use below.</p>
+            <p style="line-height: 100%">If the settings on your software that you are using to view this website (your browser) are adjusted to accept cookies we take this, and your continued use of our website, to mean that you are fine with this. Should you wish to remove or not use cookies from our site you can learn how to do this below, however doing so will likely mean that our site will not work as you would expect.</p>
+
+            <h4 style="font-weight: bold">Our own cookies</h4>
+            <p style="line-height: 100%">We use cookies to make our website work including:</p>
+            <ul>
+                <li>Remembering your search settings</li>
+                <li>Authentication to WMS, WFS, WPS via HTTP requests</li>
+            </ul>
+            <p style="line-height: 100%">There is no way to prevent these cookies being set other than to not use our site.</p>
+            <h4 style="font-weight: bold">Third Party Cookies</h4>
+            <p style="line-height: 100%">Our site, like most websites, includes functionality provided by third parties. A common example is an embedded YouTube video. Our site includes the following which use cookies:</p>
+            <ul>
+                <li><a href="http://www.google.it/intl/en/policies/privacy/" target="_blank">Google</a></li>
+                <li><a href="https://www.cloudflare.com/cookie-policy/" target="_blank">Cloudflare</a></li>
+            </ul>
+            <h4 style="font-weight: bold">Social Website Cookies</h4>
+            <p style="line-height: 100%">So you can easily like or share our content on the likes of Facebook and Twitter we have included sharing buttons on our site. Cookies are set by:</p>
+            <ul>
+                <li>Twitter</li>
+                <li>Facebook</li>
+                <li>Linkedin</li>
+                <li>Google +</li>
+            </ul>
+            <p style="line-height: 100%">The privacy implications on this will vary from social network to social network and will be dependent on the privacy settings you have chosen on these networks.</p>
+            <h4 style="font-weight: bold">Turning Cookies Off</h4>
+            <p style="line-height: 100%">
+                You can usually switch cookies off by adjusting your browser settings to stop it from accepting cookies (learn how <a      href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank"> here</a>.). Doing so however will likely limit the functionality of our’s  and a large proportion of the world’s websites as cookies are a standard part of most modern websites.
+            </p>
+            <p style="line-height: 100%">
+                It may be that you concerns around cookies relate to so called “spyware”. Rather than switching off cookies in your browser you may find that anti-spyware software achieves the same objective by automatically deleting cookies considered to be invasive. Learn more about <a href="http://www.attacat.co.uk/resources/cookies/how-to-control-your-online-privacy" target="_blank"> managing cookies with antispyware software</a>.
+            </p>
+        </div>
+    </body>
+</html>

--- a/translations/fragments/cookie/cookieDetails-zh-ZH.html
+++ b/translations/fragments/cookie/cookieDetails-zh-ZH.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div className="cookie-seeMore">
+            <h2 style="font-weight: bold">Cookies Policy</h2>
+            <hr />
+            <p style="line-height: 100%">
+                In accordance with Law Decree n° 196/2003, which replaced the Law n° 675/1996 concerning the protection of personal data, we inform you that by filling out this form and then sending this email message, you consent to the processing of your personal data (sensitive data will not be processed in any way) acquired by GeoSolutions SAS via electronic and/or automated tools. In any case, you can exercise your rights granted to you pursuant to Legislative Decree n° 196/2003 (data access, updates, integration, cancellation). Clicking the “Accept” button, you acknowledge that you have read this text and that you consent to the processing of your personal data. At any time you can ask the staff of GeoSolutions SAS web site to unsubscribe you from the service by following the instructions at the end of each message.
+            </p>
+            <h4 style="font-weight: bold">Cookies and how they Benefit You</h4>
+            <p style="line-height: 100%">Our website uses cookies, as almost all websites do, to help provide you with the best experience we can. Cookies are small text files that are placed on your computer or mobile phone when you browse websites</p>
+            <p style="line-height: 100%">Our cookies help us:</p>
+            <ul>
+                <li>Make our website work as you’d expect</li>
+                <li>Remember your settings during and between visits</li>
+                <li>Improve the speed/security of the site</li>
+                <li>Allow you to share pages with social networks like Facebook</li>
+            </ul>
+            <p style="line-height: 100%">We do not use cookies to:</p>
+            <ul>
+                <li>Collect any personally identifiable information (without your express permission)</li>
+                <li>Collect any sensitive information (without your express permission)</li>
+                <li>Pass data to advertising networks</li>
+                <li>Pass personally identifiable data to third parties</li>
+                <li>Pay sales commissions</li>
+            </ul>
+            <p style="line-height: 100%">You can learn more about all the cookies we use below.</p>
+            <p style="line-height: 100%">If the settings on your software that you are using to view this website (your browser) are adjusted to accept cookies we take this, and your continued use of our website, to mean that you are fine with this. Should you wish to remove or not use cookies from our site you can learn how to do this below, however doing so will likely mean that our site will not work as you would expect.</p>
+
+            <h4 style="font-weight: bold">Our own cookies</h4>
+            <p style="line-height: 100%">We use cookies to make our website work including:</p>
+            <ul>
+                <li>Remembering your search settings</li>
+                <li>Authentication to WMS, WFS, WPS via HTTP requests</li>
+            </ul>
+            <p style="line-height: 100%">There is no way to prevent these cookies being set other than to not use our site.</p>
+            <h4 style="font-weight: bold">Third Party Cookies</h4>
+            <p style="line-height: 100%">Our site, like most websites, includes functionality provided by third parties. A common example is an embedded YouTube video. Our site includes the following which use cookies:</p>
+            <ul>
+                <li><a href="http://www.google.it/intl/en/policies/privacy/" target="_blank">Google</a></li>
+                <li><a href="https://www.cloudflare.com/cookie-policy/" target="_blank">Cloudflare</a></li>
+            </ul>
+            <h4 style="font-weight: bold">Social Website Cookies</h4>
+            <p style="line-height: 100%">So you can easily like or share our content on the likes of Facebook and Twitter we have included sharing buttons on our site. Cookies are set by:</p>
+            <ul>
+                <li>Twitter</li>
+                <li>Facebook</li>
+                <li>Linkedin</li>
+                <li>Google +</li>
+            </ul>
+            <p style="line-height: 100%">The privacy implications on this will vary from social network to social network and will be dependent on the privacy settings you have chosen on these networks.</p>
+            <h4 style="font-weight: bold">Turning Cookies Off</h4>
+            <p style="line-height: 100%">
+                You can usually switch cookies off by adjusting your browser settings to stop it from accepting cookies (learn how <a      href="http://www.attacat.co.uk/resources/cookies/how-to-ban" target="_blank"> here</a>.). Doing so however will likely limit the functionality of our’s  and a large proportion of the world’s websites as cookies are a standard part of most modern websites.
+            </p>
+            <p style="line-height: 100%">
+                It may be that you concerns around cookies relate to so called “spyware”. Rather than switching off cookies in your browser you may find that anti-spyware software achieves the same objective by automatically deleting cookies considered to be invasive. Learn more about <a href="http://www.attacat.co.uk/resources/cookies/how-to-control-your-online-privacy" target="_blank"> managing cookies with antispyware software</a>.
+            </p>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
### title and cookies policy
This PR adds translations for cookie policy window and add custom index.html (api.html, 
embedded.html) files for suerveye theme. 

### dashboard load error
About the last issue in #18 (error for dashboards), i didn't have many clues, so I tried with some actions trying to replicate the issue. 
Seeing that the error message is triggered when the search on dashboards and maps is performed, I tried to search some maps. I tried to insert some special char (taking into account that the application is deployed on a slovak domain, so special chars will be used).

I found that searching for `|s` in home page, the popup appears. This is the request that cauese the error
```
https://maps.surveye.sk/mapstore/rest/geostore/extjs/search/category/DASHBOARD/*%7Cs*/thumbnail,details,featured?start=0&limit=12
```
this request fails only on surveye.sk server, not on mapstore dev server, and the error is somehow related to char encoding.

![image](https://user-images.githubusercontent.com/1279510/65973147-1c5cfb00-e46b-11e9-8037-38d4a3c53402.png)

for all this reasons I suppose the error is caused by server or tomcat encoding settings.